### PR TITLE
Rename avr-atmel-none to avr-unknown-unknown

### DIFF
--- a/avr-atmega328p.json
+++ b/avr-atmega328p.json
@@ -7,7 +7,7 @@
   "target-env": "",
   "target-vendor": "unknown",
   "arch": "avr",
-  "data-layout": "e-p:16:16:16-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-n8",
+  "data-layout": "e-p:16:8-i8:8-i16:8-i32:8-i64:8-f32:8-f64:8-n8-a:8",
 
   "executables": true,
 

--- a/avr-atmega328p.json
+++ b/avr-atmega328p.json
@@ -1,10 +1,10 @@
 {
-  "llvm-target": "avr-atmel-none",
+  "llvm-target": "avr-unknown-unknown",
   "cpu": "atmega328p",
   "target-endian": "little",
   "target-pointer-width": "16",
-  "os": "none",
-  "target-env": "gnu",
+  "os": "unknown",
+  "target-env": "",
   "target-vendor": "unknown",
   "arch": "avr",
   "data-layout": "e-p:16:8-i8:8-i16:8-i32:8-i64:8-f32:8-f64:8-n8-a:8",

--- a/avr-atmega328p.json
+++ b/avr-atmega328p.json
@@ -7,7 +7,7 @@
   "target-env": "",
   "target-vendor": "unknown",
   "arch": "avr",
-  "data-layout": "e-p:16:8-i8:8-i16:8-i32:8-i64:8-f32:8-f64:8-n8-a:8",
+  "data-layout": "e-p:16:16:16-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-n8",
 
   "executables": true,
 


### PR DESCRIPTION
This is what the AVR-Rust compiler uses now